### PR TITLE
Support <#C01S1JQMYKV|ru_shalm> syntax

### DIFF
--- a/lib/slack_markdown/filters/convert_filter.rb
+++ b/lib/slack_markdown/filters/convert_filter.rb
@@ -24,6 +24,7 @@ module SlackMarkdown
           when /\A#(C.+)\z/ # channel
             channel = context.include?(:on_slack_channel_id) ? context[:on_slack_channel_id].call($1) : nil
             if channel
+              override_text = nil
               ['channel', channel[:url], "##{channel[:text]}"]
             else
               ['channel', data, data]

--- a/spec/slack_markdown/processor_spec.rb
+++ b/spec/slack_markdown/processor_spec.rb
@@ -12,7 +12,7 @@ describe SlackMarkdown::Processor do
         { text: 'ru_shalm', url: '/@ru_shalm' } if uid == 'U12345'
       end,
       on_slack_channel_id: lambda do |uid|
-        { text: 'ru_shalm', url: 'http://toripota.com' } if uid == 'U12345'
+        { text: 'ru_shalm', url: 'http://toripota.com' } if uid == 'C01S1JQMYKV'
       end,
       cushion_link: 'http://localhost/?url=',
     }
@@ -22,13 +22,13 @@ describe SlackMarkdown::Processor do
 
   let :text do
     <<EOS
-<@U12345> <@U23456> *SlackMarkdown* is `text formatter` _gem_ .
+<@U12345> <@U23456> <#C01S1JQMYKV|ru_shalm> *SlackMarkdown* is `text formatter` _gem_ .
 > :ru_shalm: is <http://toripota.com/img/ru_shalm.png>
 EOS
   end
 
   it do
-    should eq "<a href=\"/@ru_shalm\" class=\"mention\">@ru_shalm</a> @U23456 <b>SlackMarkdown</b> is <code>text formatter</code> <i>gem</i> .<br><blockquote>
+    should eq "<a href=\"/@ru_shalm\" class=\"mention\">@ru_shalm</a> @U23456 <a href=\"http://localhost/?url=http%3A%2F%2Ftoripota.com\" class=\"channel\">#ru_shalm</a> <b>SlackMarkdown</b> is <code>text formatter</code> <i>gem</i> .<br><blockquote>
 <img class=\"emoji\" title=\":ru_shalm:\" alt=\":ru_shalm:\" src=\"http://toripota.com/img/ru_shalm.png\" height=\"20\" width=\"20\" align=\"absmiddle\"> is <a href=\"http://localhost/?url=http%3A%2F%2Ftoripota.com%2Fimg%2Fru_shalm.png\" class=\"link\">http://toripota.com/img/ru_shalm.png</a><br>
 </blockquote>"
   end


### PR DESCRIPTION
### Support <#C01S1JQMYKV|ru_shalm> syntax

Otherwise `#` in front of channel name was missing because `override_text` wouldn't be nil and equal to `ru_shalm` and not `#ru_shalm`