### PR TITLE
Add support for Slack emoji aliases

### DIFF
--- a/lib/slack_markdown/filters/emoji_filter.rb
+++ b/lib/slack_markdown/filters/emoji_filter.rb
@@ -26,7 +26,13 @@ module SlackMarkdown
       end
 
       def original_emoji_path(name)
-        original_emoji_set[name]
+        path = original_emoji_set[name]
+
+        if (matches = path.match(/\Aalias:(.+)\z/))
+          emoji_url(matches[1])
+        else
+          path
+        end
       end
     end
   end

--- a/spec/slack_markdown/filters/emoji_filter_spec.rb
+++ b/spec/slack_markdown/filters/emoji_filter_spec.rb
@@ -7,6 +7,8 @@ describe SlackMarkdown::Filters::EmojiFilter do
       asset_root: '/assets',
       original_emoji_set: {
         'ru_shalm' => 'http://toripota.com/img/ru_shalm.png',
+        'shalm' => 'alias:ru_shalm',
+        'happy' => 'alias:smile'
       },
     }
     filter = SlackMarkdown::Filters::EmojiFilter.new(text, context)
@@ -21,5 +23,15 @@ describe SlackMarkdown::Filters::EmojiFilter do
   context ':ru_shalm: is my avatar' do
     let(:text) { ':ru_shalm: is my avatar' }
     it { should eq '<img class="emoji" title=":ru_shalm:" alt=":ru_shalm:" src="http://toripota.com/img/ru_shalm.png" height="20" width="20" align="absmiddle"> is my avatar' }
+  end
+
+  context ':shalm: is an emoji alias' do
+    let(:text) { ':shalm: is an emoji alias' }
+    it { should eq '<img class="emoji" title=":shalm:" alt=":shalm:" src="http://toripota.com/img/ru_shalm.png" height="20" width="20" align="absmiddle"> is an emoji alias' }
+  end
+
+  context ':happy: is aliased to a standard unicode emoji' do
+    let(:text) { ':happy: is aliased to a standard unicode emoji' }
+    it { should eq '<img class="emoji" title=":happy:" alt=":happy:" src="/assets/emoji/unicode/1f604.png" height="20" width="20" align="absmiddle"> is aliased to a standard unicode emoji' }
   end
 end


### PR DESCRIPTION
Slack lets you add custom emoji as aliases to other emoji. When requesting a workspace's custom emoji from the [`emoji.list` API endpoint](https://api.slack.com/methods/emoji.list) (which is a convenient way to populate the `original_emoji_set` option), emoji aliases follow a pattern:

```json
{
  "ok": true,
  "emoji": {
    "simple_smile": "https://a.slack-edge.com/80588/img/emoji_2017_12_06/apple/simple_smile.png",
    "octocat": "https://emoji.slack-edge.com/T02F9SUA63B/octocat/85961c43d7.png",
    "github": "alias:octocat",
    "happy":"alias:smile"
  },
  "cache_ts": "1635536920.033500"
}
```

You can add emoji as an alias to both other custom emoji, or even the stock unicode emoji. This patch supports both ✨