### PR TITLE
Add support for ~strikethrough~ text

### DIFF
--- a/lib/slack_markdown/filters/strike_filter.rb
+++ b/lib/slack_markdown/filters/strike_filter.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+require 'html/pipeline'
+require 'slack_markdown/filters/ignorable_ancestor_tags'
+
+module SlackMarkdown
+  module Filters
+    class StrikeFilter < ::HTML::Pipeline::Filter
+      include IgnorableAncestorTags
+
+      def call
+        doc.search('.//text()').each do |node|
+          content = node.to_html
+          next if has_ancestor?(node, ignored_ancestor_tags)
+          next unless content.include?('~')
+          html = strike_filter(content)
+          next if html == content
+          node.replace(html)
+        end
+        doc
+      end
+
+      def strike_filter(text)
+        text.gsub(STRIKE_PATTERN) do
+          "<strike>#{$1}</strike>"
+        end
+      end
+
+      STRIKE_PATTERN = /(?<=^|\W)~(.+)~(?=\W|$)/
+    end
+  end
+end

--- a/lib/slack_markdown/processor.rb
+++ b/lib/slack_markdown/processor.rb
@@ -9,6 +9,7 @@ require 'slack_markdown/filters/code_filter'
 require 'slack_markdown/filters/emoji_filter'
 require 'slack_markdown/filters/bold_filter'
 require 'slack_markdown/filters/italic_filter'
+require 'slack_markdown/filters/strike_filter'
 require 'slack_markdown/filters/line_break_filter'
 
 module SlackMarkdown
@@ -28,6 +29,7 @@ module SlackMarkdown
         SlackMarkdown::Filters::EmojiFilter,
         SlackMarkdown::Filters::BoldFilter,
         SlackMarkdown::Filters::ItalicFilter,
+        SlackMarkdown::Filters::StrikeFilter,
         SlackMarkdown::Filters::LineBreakFilter,
       ]
     end

--- a/spec/slack_markdown/filters/strike_filter_spec.rb
+++ b/spec/slack_markdown/filters/strike_filter_spec.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe SlackMarkdown::Filters::StrikeFilter do
+  subject do
+    filter = SlackMarkdown::Filters::StrikeFilter.new(text)
+    filter.call.to_s
+  end
+
+  context '~hoge~' do
+    let(:text) { '~hoge~' }
+    it { should eq '<strike>hoge</strike>' }
+  end
+
+  context 'hoge~fuga~poyo' do
+    let(:text) { 'hoge~fuga~poyo' }
+    it { should eq 'hoge~fuga~poyo' }
+  end
+
+  context 'hoge ~fuga~ poyo' do
+    let(:text) { 'hoge ~fuga~ poyo' }
+    it { should eq 'hoge <strike>fuga</strike> poyo' }
+  end
+end

--- a/spec/slack_markdown/processor_spec.rb
+++ b/spec/slack_markdown/processor_spec.rb
@@ -22,13 +22,13 @@ describe SlackMarkdown::Processor do
 
   let :text do
     <<EOS
-<@U12345> <@U23456> *SlackMarkdown* is `text formatter` _gem_ .
+<@U12345> <@U23456> *SlackMarkdown* is `text formatter` ~package~ _gem_ .
 > :ru_shalm: is <http://toripota.com/img/ru_shalm.png>
 EOS
   end
 
   it do
-    should eq "<a href=\"/@ru_shalm\" class=\"mention\">@ru_shalm</a> @U23456 <b>SlackMarkdown</b> is <code>text formatter</code> <i>gem</i> .<br><blockquote>
+    should eq "<a href=\"/@ru_shalm\" class=\"mention\">@ru_shalm</a> @U23456 <b>SlackMarkdown</b> is <code>text formatter</code> <strike>package</strike> <i>gem</i> .<br><blockquote>
 <img class=\"emoji\" title=\":ru_shalm:\" alt=\":ru_shalm:\" src=\"http://toripota.com/img/ru_shalm.png\" height=\"20\" width=\"20\" align=\"absmiddle\"> is <a href=\"http://localhost/?url=http%3A%2F%2Ftoripota.com%2Fimg%2Fru_shalm.png\" class=\"link\">http://toripota.com/img/ru_shalm.png</a><br>
 </blockquote>"
   end


### PR DESCRIPTION
This is just a simple filter for ~~strikethrough~~ text, like the **bold** or _italic_ filters!