### PR TITLE
Fix override_text clobbering custom User mention text

### DIFF
--- a/lib/slack_markdown/filters/convert_filter.rb
+++ b/lib/slack_markdown/filters/convert_filter.rb
@@ -32,6 +32,7 @@ module SlackMarkdown
           when /\A@((?:U|B).+)/ # user or bot
             user = context.include?(:on_slack_user_id) ? context[:on_slack_user_id].call(Regexp.last_match(1)) : nil
             if user
+              override_text = nil
               ['mention', user[:url], "@#{user[:text]}"]
             else
               ['mention', nil, data]
@@ -39,6 +40,7 @@ module SlackMarkdown
           when /\A@(.+)/ # user name
             user = context.include?(:on_slack_user_name) ? context[:on_slack_user_name].call(Regexp.last_match(1)) : nil
             if user
+              override_text = nil
               ['mention', user[:url], "@#{user[:text]}"]
             else
               ['mention', nil, data]

--- a/spec/slack_markdown/processor_spec.rb
+++ b/spec/slack_markdown/processor_spec.rb
@@ -23,14 +23,15 @@ describe SlackMarkdown::Processor do
 
   let :text do
     <<~EOS
-      <@U12345> <@U23456> <#C01S1JQMYKV|ru_shalm> *SlackMarkdown* is `text formatter` ~package~ _gem_ .
+      <@U12345> <@U23456> <#C01S1JQMYKV> *SlackMarkdown* is `text formatter` ~package~ _gem_ .
       > :ru_shalm: is <http://toripota.com/img/ru_shalm.png>
+      <@U12345|dont_override_me> <@U23456|override_me> <#C01S1JQMYKV|dont_override_me> <#C12345|override_me>
     EOS
   end
 
   it do
     should eq "<a href=\"/@ru_shalm\" class=\"mention\">@ru_shalm</a> @U23456 <a href=\"http://localhost/?url=http%3A%2F%2Ftoripota.com\" class=\"channel\">#ru_shalm</a> <b>SlackMarkdown</b> is <code>text formatter</code> <strike>package</strike> <i>gem</i> .<br><blockquote>
 <img class=\"emoji\" title=\":ru_shalm:\" alt=\":ru_shalm:\" src=\"http://toripota.com/img/ru_shalm.png\" height=\"20\" width=\"20\" align=\"absmiddle\"> is <a href=\"http://localhost/?url=http%3A%2F%2Ftoripota.com%2Fimg%2Fru_shalm.png\" class=\"link\">http://toripota.com/img/ru_shalm.png</a><br>
-</blockquote>"
+</blockquote><a href=\"/@ru_shalm\" class=\"mention\">@ru_shalm</a> override_me <a href=\"http://localhost/?url=http%3A%2F%2Ftoripota.com\" class=\"channel\">#ru_shalm</a> <a href=\"#C12345\" class=\"channel\">override_me</a><br>"
   end
 end


### PR DESCRIPTION
It looks like the problem that was fixed in #4 is actually also a problem for user mentions! If you have a user mention (e.g. `<@U39AS042DN|username>`) in your markdown and have specified a `on_slack_user_id` block for your processor that matches this user, the link text will always end up being `username` and the custom text provided in the `on_slack_user_id` block won't render. This is important to fix for User mentions too because when Slack sends something like `<@U39AS042DN|username>`, they're actually sending their old legacy username (the `name` field in User API responses that they say [not to use](https://api.slack.com/changelog/2017-09-the-one-about-usernames)).

